### PR TITLE
Fix URL parsing in server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const fs = require('fs').promises;
 const path = require('path');
+const { URL } = require('url');
 
 // Define the root directory for serving files
 const rootDirectory = path.join(__dirname, '../');
@@ -25,8 +26,9 @@ const server = http.createServer(async (req, res) => {
   try {
     console.log('Request:', req.url);
 
-    // Normalize and construct the file path
-    let safePath = path.normalize(decodeURIComponent(req.url));
+    // Normalize and construct the file path without query parameters
+    const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+    let safePath = path.normalize(parsedUrl.pathname);
     if (safePath === '/' || safePath === '') safePath = '/index.html';
     if (!path.extname(safePath)) safePath += '.html';
     


### PR DESCRIPTION
## Summary
- ensure the custom HTTP server strips query parameters
- include Node's `URL` API

## Testing
- `node server/server.js >/tmp/server.log 2>&1 &`
- `cat /tmp/server.log`

------
https://chatgpt.com/codex/tasks/task_e_68401c41065c8320b3d4e03d915825ee